### PR TITLE
Ensure all listeners receive the event, even if one raises an exception

### DIFF
--- a/lib/event_bus.rb
+++ b/lib/event_bus.rb
@@ -69,6 +69,22 @@ class EventBus
     alias :listen_for :subscribe
 
     #
+    # Register a global error handler
+    #
+    # The supplied block will be called once for each error that is raised by
+    # any listener, for any event.
+    #
+    # The block will be provided with two parameters, the listener that errored,
+    # and the payload of the event.
+    #
+    # @param blk the block to be called when any unhandled error occurs in a listener
+    # @return [EventBus] the EventBus, ready to be called again
+    def on_error(&blk)
+      registrations.on_error &blk
+      self
+    end
+
+    #
     # Delete all current listener registrations
     #
     # @return the EventBus, ready to be called again.


### PR DESCRIPTION
If a listener raises an error, ensure that all other listeners still
receive the event.

Additionally allow the registration of an error handler that is call if
a listener raises an error. The handler gets the listener (either the
specified object or the source block) and the full_payload.
