### PR TITLE
Decorate the payload with the error for the error handler.

### DIFF
--- a/lib/event_bus/registrations.rb
+++ b/lib/event_bus/registrations.rb
@@ -44,7 +44,7 @@ class EventBus
       begin
         listener.respond(event_name, payload)
       rescue => error
-        error_handler.call(listener.receiver, payload) if error_handler
+        error_handler.call(listener.receiver, payload.merge(error: error)) if error_handler
       end
     end
 

--- a/spec/lib/event_bus_spec.rb
+++ b/spec/lib/event_bus_spec.rb
@@ -41,9 +41,10 @@ describe EventBus do
   end
 
   describe 'publishing with errors' do
+    Given(:error) { RuntimeError.new }
     Given(:erroring_listener) { double(:erroring_listener) }
     Given(:error_handler) { double(:error_handler, handle_error: true) }
-    Given { erroring_listener.stub(:handler) { raise RuntimeError.new } }
+    Given { erroring_listener.stub(:handler) { raise error } }
 
     context 'sends the event to the second listener when the first errors' do
       Given { EventBus.subscribe('aa123bb', erroring_listener, :handler) }
@@ -60,13 +61,13 @@ describe EventBus do
       context 'when the listener is an object' do
         Given { EventBus.subscribe('aa123bb', erroring_listener, :handler) }
         When { EventBus.publish('aa123bb') }
-        Then { error_handler.should have_received(:handle_error).with(erroring_listener, event_name: 'aa123bb') }
+        Then { error_handler.should have_received(:handle_error).with(erroring_listener, event_name: 'aa123bb', error: error ) }
       end
 
       context 'when the listener is a block' do
-        Given { EventBus.subscribe('aa123bb') {|info| raise RuntimeError.new } }
+        Given { EventBus.subscribe('aa123bb') {|info| raise error } }
         When { EventBus.publish('aa123bb') }
-        Then { error_handler.should have_received(:handle_error).with(instance_of(Proc), event_name: 'aa123bb') }
+        Then { error_handler.should have_received(:handle_error).with(instance_of(Proc), event_name: 'aa123bb', error: error) }
       end
 
     end


### PR DESCRIPTION
If we have an error handler, inject the error into the payload so the handler
has access to it.
