### PR TITLE
Update travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: ruby
+bundler_args: ''
 rvm:
-  - '1.9.2'
-  - '1.9.3'
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
   - jruby-19mode
-  - rbx-19mode
-
+  - rbx-2.1
+  - rbx-2.2
+matrix:
+  allow_failures:
+    - rvm: rbx-2.1
+    - rvm: rbx-2.2


### PR DESCRIPTION
- Add ruby 2.0.0 and 2.1.0 to travis builds
- remove obsolete rbx-19mode
- add rbx-2.1 and rbx-2.2 as allowed failures (rbx setup fails on travis)
- ensure travis doesn't append '-- deployment' to bundle install
