### PR TITLE
Dispach class/object registrations differently

### DIFF
--- a/lib/event_bus.rb
+++ b/lib/event_bus.rb
@@ -108,10 +108,7 @@ class EventBus
     end
 
     def subscribe_obj(listener)
-      registrations.add_block(/.*/) do |payload|
-        method = payload[:event_name].to_sym
-        listener.send(method, payload) if listener.respond_to?(method)
-      end
+      registrations.add_method(/.*/, listener, nil)
     end
 
     def registrations

--- a/lib/event_bus/registrations.rb
+++ b/lib/event_bus/registrations.rb
@@ -50,7 +50,9 @@ class EventBus
 
     Registration = Struct.new(:pattern, :listener, :method_name) do
       def respond(event_name, payload)
-        listener.send(method_name, payload) if pattern === event_name
+        target = method_name || event_name
+
+        listener.send(target, payload) if pattern === event_name && listener.respond_to?(target)
       end
 
       def receiver


### PR DESCRIPTION
Instead of creating a block for object based subcriptions, create a
method based registration.  Addtionally update the method registrations
to use the event name if there's no specific method name.

This facilitates decoration event dispatching with logging (from RPM, as
an example) for performance troubleshooting.
