### PR TITLE
Add section about error handling to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,34 @@ There are three ways to subscribe to events.
 
 See the specs for more detailed usage scenarios.
 
+### Error Handling
+
+Any exception risen by the event listeners will be swallowed not affecting the execution flow. In order to handle errors you can register a global error handler:
+
+```ruby
+EventBus.on_error do |listener, payload|
+  #handle the error
+end
+```
+
+The supplied block will be called once for each error that is raised by any listener, for any event.
+
+The block will be provided with two parameters, the listener that errored, and the payload of the event. The payload of the event will have an extra `error` value containing the exception object that was risen:
+
+```ruby
+EventBus.on_error do |listener, payload|
+  puts listener.inspect        # => #<Proc:0x007fec9305a500@lib/event_bus_example.rb:10>
+  puts payload.inspect         # => {:event_name=>:order_placed, :order_id=>1, :error=>#<StandardError: something went wrong>}
+  puts payload[:error].inspect # => #<StandardError: something went wrong>
+end
+
+EventBus.subscribe(:order_placed) do |payload|
+  raise StandardError, 'something went wrong'
+end
+
+EventBus.announce(:order_placed, order_id: 1)
+```
+
 ## Compatibility
 
 Tested with Ruby 2.1, 2.0, 1.9.x, JRuby.


### PR DESCRIPTION
I was testing the gem and was puzzled when this wasn't working:

``` ruby
EventBus.subscribe(:test) do
  raise 'foo'
end

EventBus.announce(:test)
```

It's easy enough to figure out what's going on by looking at the code but a tiny section on the README may help. The text is mostly the same as the documentation for the `on_error` method extended a little bit with an example.
